### PR TITLE
Kill dock before updating

### DIFF
--- a/logon.script.sh
+++ b/logon.script.sh
@@ -58,6 +58,8 @@ done
 
 # ---------------------------------------------
 
+killall Dock
+
 # Update Dock
 /usr/local/bin/dockutil --remove all \
     --add /Applications/Google\ Chrome.app \


### PR DESCRIPTION
It wasn't working after updating to Ventura. This seems to fix it.